### PR TITLE
Added Features for saving tournaments

### DIFF
--- a/server/models/match.go
+++ b/server/models/match.go
@@ -17,6 +17,7 @@ type Match interface {
 	Status() int
 	SetStatus(int)
 	Start() interfaces.Player
+	ToJson() 	  string
 }
 
 type MatchData struct {
@@ -108,10 +109,6 @@ func (m *MatchData) Status() int {
 // funcion para settear el estado de la partida
 func (m *MatchData) SetStatus(status int) {
 	m.MatchStatus_ = status
-}
-
-// funcion para cargar los datos de la partida desde un .json
-func (m *MatchData) LoadState() {
 }
 
 func (m *MatchData) Start() interfaces.Player {

--- a/server/models/tournament.go
+++ b/server/models/tournament.go
@@ -20,8 +20,8 @@ type Tournament interface {
 	Status() pb.TournamentStatus
 	State() map[string]interface{}
 	SetState(key string, value interface{})
-	LoadState()
 	PendingMatches() map[int]bool
+	ToJson() string
 }
 
 var initialState = map[string]interface{}{
@@ -84,7 +84,7 @@ func NewTournamentData(id string, players []interfaces.Player, gameFactory func(
 	}
 }
 
-func (t *TournamentData) FromJson(jsonData string) *TournamentData {
+func TournamentFromJson(jsonData string) *TournamentData {
 	var data *TournamentData
 
 	err := json.Unmarshal([]byte(jsonData), data)
@@ -151,9 +151,6 @@ func (t *TournamentData) SetWinner(winner interfaces.Player) {
 	t.State_["winner"] = winner
 }
 
-// funcion para cargar el estado del torneo desde un .json
-func (t *TournamentData) LoadState() {
-}
 
 func (t *TournamentData) PendingMatches() map[int]bool {
 	return t.PendingMatches_

--- a/server/tournaments/manager.go
+++ b/server/tournaments/manager.go
@@ -36,6 +36,17 @@ func (tm *TournamentManager) AddTournament(tournament models.Tournament) {
 	// Aqui hay que hacer la replicacion a los siguientes k - 1 nodos con k factor de replicacion
 }
 
+func (tm *TournamentManager) ResumeTournament(json string) {
+	tournament:= models.TournamentFromJson(json)
+	tm.Tournaments[tournament.Id()] = tournament
+
+	go NewTournamentRunner(tm, tournament).Resume()
+}
+
+func (tm *TournamentManager) SaveTournamentAsJson(id string, json string) {
+	
+}
+
 func (tm *TournamentManager) UpdateTournament(tournament models.Tournament) {
 	tm.Tournaments[tournament.Id()] = tournament
 }


### PR DESCRIPTION
- Cambie la funcion de FromJson de torneo para que simplemente instanciara un torneo a partir del string, o sea que no necesita un objeto tournament para crear un objeto tournament.(Cambialo si da problemas a la hora de parsear del Json)
- Agregue un sleep de 3 segundos en RunMatch para que no termine de inmediato, con unas 1024 partidas el torneo deberia demorar unos 30 segundos, pero eso se puede cambiar.
- Si a la hora de parsear el torneo da problemas entonces es posible que haya que crear un serializer tanto de tictactoe como de los players, todavia no se como funciona el parseo a json
- Agregue funciones para reanudar un torneo a partir de un Save(json) tanto en el Runner como en el Manager
- Agregue una funcion Save dentro del tournamentRunner tienes que llamarla tanto desde el Run() como del Resume() con una gorutine, sugiero meter el codigo del Save dentro de un for y ponerle un sleep de unos 5 segundos para que guarde el estado constantemente.
- Agregue una funcion SaveTournament en el Manager (a esta la llamo desde el Runner) esta vacia pero se supone que esta funcion se comunica con la Red de cord para que replique los datos en varios servers. 